### PR TITLE
RegistryConfigurationSubKeyParser with REG_MULTI_SZ support

### DIFF
--- a/Xello.RegistryConfigurationManager.Tests.Integration/RegistryConfigurationSubKeyParserTests.cs
+++ b/Xello.RegistryConfigurationManager.Tests.Integration/RegistryConfigurationSubKeyParserTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32;
 using System.Collections.Generic;
 
 namespace Xello.RegistryConfigurationManager.Tests.Integration
@@ -6,14 +7,23 @@ namespace Xello.RegistryConfigurationManager.Tests.Integration
     [TestClass]
     public class RegistryConfigurationSubKeyParserTests
     {
+        private string _path = @"SOFTWARE\xellotest";
+
 
         [TestMethod]
         public void Can_Parse_String()
         {
-            var Data = RegistryConfigurationSubKeyParser.Parse(@"SOFTWARE\xellotest");
+            var editor = new RegistryEditor(Registry.LocalMachine, _path);
 
             var valueName = "Test:String";
             var expectedValue = "This is a test string";
+
+            editor.SetValue(valueName, expectedValue);
+
+            var Data = RegistryConfigurationSubKeyParser.Parse(_path);
+
+            editor.Cleanup();
+
             Assert.IsTrue(Data.ContainsKey(valueName));
 
             Assert.AreEqual(expectedValue, Data[valueName]);
@@ -23,12 +33,18 @@ namespace Xello.RegistryConfigurationManager.Tests.Integration
         [TestMethod]
         public void Can_Parse_Array()
         {
-            var Data = RegistryConfigurationSubKeyParser.Parse(@"SOFTWARE\xellotest");
+            var editor = new RegistryEditor(Registry.LocalMachine, _path);
 
             var valueName = "Test:Array";
-            var expectedValues = new List<string> { "a", "b", "c", "d", "e" };
+            var expectedValues = new string[] { "a", "b", "c", "d", "e" };
 
-            for (int i = 0; i < expectedValues.Count; ++i)
+            editor.SetValue(valueName, expectedValues, RegistryValueKind.MultiString);
+
+            var Data = RegistryConfigurationSubKeyParser.Parse(_path);
+
+            editor.Cleanup();
+
+            for (int i = 0; i < expectedValues.Length; ++i)
             {
                 var valueIndex = valueName + ":" + i.ToString();
                 Assert.IsTrue(Data.ContainsKey(valueIndex));

--- a/Xello.RegistryConfigurationManager.Tests.Integration/RegistryConfigurationSubKeyParserTests.cs
+++ b/Xello.RegistryConfigurationManager.Tests.Integration/RegistryConfigurationSubKeyParserTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace Xello.RegistryConfigurationManager.Tests.Integration
+{
+    [TestClass]
+    public class RegistryConfigurationSubKeyParserTests
+    {
+
+        [TestMethod]
+        public void Can_Parse_String()
+        {
+            var Data = RegistryConfigurationSubKeyParser.Parse(@"SOFTWARE\xellotest");
+
+            var valueName = "Test:String";
+            var expectedValue = "This is a test string";
+            Assert.IsTrue(Data.ContainsKey(valueName));
+
+            Assert.AreEqual(expectedValue, Data[valueName]);
+        }
+
+
+        [TestMethod]
+        public void Can_Parse_Array()
+        {
+            var Data = RegistryConfigurationSubKeyParser.Parse(@"SOFTWARE\xellotest");
+
+            var valueName = "Test:Array";
+            var expectedValues = new List<string> { "a", "b", "c", "d", "e" };
+
+            for (int i = 0; i < expectedValues.Count; ++i)
+            {
+                var valueIndex = valueName + ":" + i.ToString();
+                Assert.IsTrue(Data.ContainsKey(valueIndex));
+                Assert.AreEqual(expectedValues[i], Data[valueIndex]);
+            }
+        }
+    }
+}

--- a/Xello.RegistryConfigurationManager.Tests.Integration/RegistryEditor.cs
+++ b/Xello.RegistryConfigurationManager.Tests.Integration/RegistryEditor.cs
@@ -39,8 +39,15 @@ namespace Xello.RegistryConfigurationManager.Tests.Integration
         public void SetValue(string name, string value)
         {
             var key = _hkey.CreateSubKey(Subkey);
-            key.SetValue(name, value);            
-            key.Close();            
+            key.SetValue(name, value);
+            key.Close();
+        }
+
+        public void SetValue(string name, object value, RegistryValueKind registryValueKind)
+        {
+            var key = _hkey.CreateSubKey(Subkey);
+            key.SetValue(name, value, registryValueKind);
+            key.Close();
         }
     }
 }

--- a/Xello.RegistryConfigurationManager/RegistryConfigurationProvider.cs
+++ b/Xello.RegistryConfigurationManager/RegistryConfigurationProvider.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Xello.RegistryConfigurationManager
 {
@@ -19,14 +14,7 @@ namespace Xello.RegistryConfigurationManager
         
         public override void Load()
         {
-            using (RegistryKey regKey = Registry.LocalMachine.OpenSubKey(_path))
-            {
-                if (regKey != null)
-                {
-                    var keys = regKey.GetValueNames();
-                    Data = keys.ToDictionary(key => key, key => regKey.GetValue(key).ToString());
-                }
-            }
+            Data = RegistryConfigurationSubKeyParser.Parse(_path);
         }
 
         public override void Set(string name, string value)

--- a/Xello.RegistryConfigurationManager/RegistryConfigurationSubKeyParser.cs
+++ b/Xello.RegistryConfigurationManager/RegistryConfigurationSubKeyParser.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Xello.RegistryConfigurationManager.Tests.Integration")]
+namespace Xello.RegistryConfigurationManager
+{
+
+    internal class RegistryConfigurationSubKeyParser
+    {
+        private RegistryConfigurationSubKeyParser() { }
+
+        private readonly IDictionary<string, string> _data = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Stack<string> _context = new Stack<string>();
+        private string _currentPath;
+
+        public static IDictionary<string, string> Parse(string keyPath)
+            => new RegistryConfigurationSubKeyParser().ParseKeyPath(keyPath);
+
+        private IDictionary<string, string> ParseKeyPath(string keyPath)
+        {
+            _data.Clear();
+
+            VisitSubKey(keyPath);
+
+            return _data;
+        }
+
+        private void VisitSubKey(string keyPath)
+        {
+            using (RegistryKey subKey = Registry.LocalMachine.OpenSubKey(keyPath))
+            {
+                if (subKey != null)
+                {
+                    foreach (var keyName in subKey.GetSubKeyNames())
+                    {
+                        EnterContext(keyName);
+                        VisitSubKey(keyPath + "\\" + keyName);
+                        ExitContext();
+                    }
+
+                    foreach (var valueName in subKey.GetValueNames())
+                    {
+                        EnterContext(valueName);
+                        VisitValue(subKey, valueName);
+                        ExitContext();
+                    }
+                }
+            }
+        }
+
+        private void VisitValue(RegistryKey subKey, string valueName)
+        {
+            switch (subKey.GetValueKind(valueName))
+            {
+                case RegistryValueKind.MultiString:
+                    VisitMultiStringValue(subKey, valueName);
+                    break;
+
+                case RegistryValueKind.String:
+                    VisitStringValue(subKey, valueName);
+                    break;
+
+                default:
+                    throw new FormatException($"Unsupported {nameof(RegistryValueKind)}");
+            }
+        }
+
+        private void VisitMultiStringValue(RegistryKey subKey, string valueName)
+        {
+            if (subKey.GetValue(valueName) is string[] array)
+            {
+                for (int index = 0; index < array.Length; index++)
+                {
+                    EnterContext(index.ToString());
+
+                    string key = _currentPath;
+                    if (_data.ContainsKey(key))
+                    {
+                        throw new FormatException($"Key Already Exists in Data ({key})");
+                    }
+                    _data[key] = array[index];
+
+                    ExitContext();
+                }
+            }
+        }
+
+        private void VisitStringValue(RegistryKey subKey, string valueName)
+        {
+            string key = _currentPath;
+            string value = subKey.GetValue(valueName).ToString();
+
+            if (_data.ContainsKey(key))
+            {
+                throw new FormatException($"Key Already Exists in Data ({key})");
+            }
+
+            _data[key] = value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private void EnterContext(string context)
+        {
+            _context.Push(context);
+            _currentPath = ConfigurationPath.Combine(_context.Reverse());
+        }
+
+        private void ExitContext()
+        {
+            _context.Pop();
+            _currentPath = ConfigurationPath.Combine(_context.Reverse());
+        }
+    }
+}


### PR DESCRIPTION
:(

This PR is technically unnecessary since arrays can be represented in registry with pure strings (see image) -- as I found out writing the code/based on the internal IDictionary<string,string> representations used by configuration providers.

![image](https://user-images.githubusercontent.com/15749177/98313781-98950c80-1fa2-11eb-9f19-6fbcbc40efa4.png)

Either way This PR would add the ability to have subkeys and REG_MULTI_SZ values, and make it easier to expand support to other REG_ value types like BIT or INT.

![image](https://user-images.githubusercontent.com/15749177/98315284-e0696300-1fa5-11eb-9d70-583f98b6b925.png)

This code is heavily based on 
https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationProvider.cs
and
https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs


